### PR TITLE
This should fix the crash in the release build

### DIFF
--- a/demoMetroSettings/proguard-rules.pro
+++ b/demoMetroSettings/proguard-rules.pro
@@ -19,3 +19,6 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Make sure protobuf files are kept for (de)serialization
+-keep class * extends com.google.protobuf.GeneratedMessageLite { *; }


### PR DESCRIPTION
```
Caused by: java.lang.RuntimeException: Field isTallScreenRatio_ for 05.c not found. Known fields are [public float 05.c.0, public float o5.c.p, ...
```

Seems like all field names are obfuscated. 