### PR TITLE
Improve the `Pages` (Pivot control) component

### DIFF
--- a/metro/src/main/java/com/louis993546/metro/Pages.kt
+++ b/metro/src/main/java/com/louis993546/metro/Pages.kt
@@ -1,27 +1,30 @@
 package com.louis993546.metro
 
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.clickable
+import android.util.Log
+import androidx.compose.animation.*
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
 
 /**
  * TODO [pageTitles] should contain each page title
  * TODO it'd be great if [pageTitles] can be some enum
  */
+@OptIn(ExperimentalAnimationApi::class)
 @ExperimentalFoundationApi
 @Composable
 fun Pages(
@@ -29,7 +32,10 @@ fun Pages(
     pageTitles: List<String>,
     page: @Composable BoxScope.(pageNumber: Int) -> Unit,
 ) {
-    Column(modifier = modifier) {
+    Column(
+        modifier = modifier
+            .padding(horizontal = 12.dp),
+    ) {
         val pageCount = pageTitles.size
 
         val scope = rememberCoroutineScope()
@@ -40,33 +46,83 @@ fun Pages(
         // TODO connect scrollState and pagerState together somehow
 
         LaunchedEffect(pagerState) {
-            snapshotFlow { pagerState.currentPage }.collect {
-                // TODO: Titles parallax scrolling (eg pivot control)
+            snapshotFlow { pagerState.isScrollInProgress }.filter { it }.collect {
+                listState.scrollToItem(pagerState.currentPage)
+            }
+        }
+        LaunchedEffect(pagerState) {
+            snapshotFlow {
+                Pair (
+                    pagerState.isScrollInProgress,
+                    pagerState.currentPageOffsetFraction
+                )
+            }.filter { it.first }.collect { it ->
+                // Titles parallax scrolling (eg pivot control)
+                // FIXME: This is probably extremely inefficient.
+                val page = pagerState.settledPage
+                var target = page + 1
+                var item = listState.layoutInfo.visibleItemsInfo.firstOrNull() { it.key == page }
+
+                // Swiping backwards
+                var backwards = false
+                if (pagerState.settledPage > pagerState.targetPage || pagerState.settledPage > pagerState.currentPage) {
+                    backwards = true
+                    target = page - 1
+                    item = listState.layoutInfo.visibleItemsInfo.firstOrNull() { it.index % pageCount == (page - 1) % pageCount }
+                    if (item == null)
+                        item = listState.layoutInfo.visibleItemsInfo.lastOrNull()
+                }
+
+                if (item == null) {
+                    // FIXME
+                    Log.w("GUI", "Couldn't get label")
+                    return@collect
+                }
+
+                var offset = it.second
+                if (it.second < 0f && !backwards)
+                    offset += 1.05f
+                else if (it.second > 0f && backwards)
+                    offset -= 1.05f
+
+                // Easing
+                offset = FastOutSlowInEasing.transform(offset)
+
+                // Finally scroll the label into view with the offset we created
+                val res = (offset * item!!.size).roundToInt()
+                listState.scrollToItem(if (res != 0 || pagerState.currentPage == page) page else target, res)
+            }
+        }
+        LaunchedEffect(pagerState) {
+            snapshotFlow { pagerState.settledPage }.collect {
                 listState.animateScrollToItem(it)
             }
         }
 
         LazyRow(
             state = listState,
-            contentPadding = PaddingValues(horizontal = 8.dp),
             userScrollEnabled = false,
             horizontalArrangement = Arrangement.spacedBy(
                 space = 16.dp,
                 alignment = Alignment.Start,
-            ),
+            )
         ) {
             items(
                 // See HorizontalPager pageCount comment for more info
                 count = Int.MAX_VALUE,
+                key = { it },
                 itemContent = {
                     val index = it % pageCount
 
                     Text(
                         text = pageTitles[index],
-                        size = 48.sp,
+                        size = 52.sp,
                         weight = FontWeight.Light,
-                        color = if (pagerState.currentPage % pageCount == index) LocalTextOnBackgroundColor.current
-                        else LocalTextOnBackgroundColor.current.copy(alpha = 0.4f),
+                        // Handle duplicates
+                        // TODO: Fade in
+                        color = if (pagerState.settledPage + pageCount <= it) Color.Transparent
+                        else if (pagerState.settledPage % pageCount == index) LocalTextOnBackgroundColor.current
+                        else LocalTextOnBackgroundColor.current.copy(alpha = 0.35f),
                         modifier = Modifier.clickable {
                             // 2 scopes to make sure the animations won't wait for one another
                             scope.launch {
@@ -75,7 +131,7 @@ fun Pages(
                             scope2.launch {
                                 pagerState.animateScrollToPage(it)
                             }
-                        }
+                        },
                     )
                 }
             )
@@ -83,12 +139,15 @@ fun Pages(
         HorizontalPager(
             modifier = Modifier.weight(1f),
             state = pagerState,
+            contentPadding = PaddingValues(top = 20.dp),
             // Ugly hack to support infinite/looping scrolling,
             // officially recommended by @google/accompanist.
             pageCount = Int.MAX_VALUE,
         ) { index ->
-            Box(modifier = Modifier.fillMaxWidth().fillMaxHeight()) {
-                this.page(index % pageCount)
+            Box(
+                modifier = Modifier.fillMaxWidth().fillMaxHeight()
+            ) {
+                page(index % pageCount)
             }
         }
     }
@@ -104,7 +163,11 @@ fun TitleBar(
 ) {
     Text(
         text = title,
-        size = 20.sp,
-        modifier = modifier.padding(all = 8.dp),
+        size = 18.sp,
+        weight = FontWeight.Bold,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp)
+            .padding(top = 8.dp),
     )
 }


### PR DESCRIPTION
This PR fixes the `Pages` (or as Windows Phone refers to it `Pivot Control`) component getting it closer in line with Windows Phone 8. For example infinite looping and parallax titles/labels.

Also; fair warning, this is the first time I ever touch kotlin, so I might've missed something obvious.

https://user-images.githubusercontent.com/108444335/235350016-c8a1166e-3bc9-439b-9f8b-7152f998ad47.mp4

