### PR TITLE
Metro: Refactor `forceTapAnimation` into `TiltIndication` - Fixes #192

### DIFF
--- a/demoAppDrawer/src/main/java/com/louis993546/metro/demo/appDrawer/DrawerPage.kt
+++ b/demoAppDrawer/src/main/java/com/louis993546/metro/demo/appDrawer/DrawerPage.kt
@@ -3,6 +3,7 @@ package com.louis993546.metro.demo.appDrawer
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -11,7 +12,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.louis993546.metro.CircleButton
@@ -76,19 +76,15 @@ fun SearchButton(
         modifier = modifier
             .size(48.dp)
             .padding(4.dp)
+            .clickable {
+                onClick()
+            }
     ) {
         Image(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(8.dp)
-                .scale(scaleX = -1f, scaleY = 1f)
-                .pointerInput(Unit) {
-                    detectTapGestures(
-                        onPress = {
-                            onClick()
-                        }
-                    )
-                },
+                .scale(scaleX = -1f, scaleY = 1f),
             painter = painterResource(id = R.drawable.ic_baseline_search_24),
             contentDescription = "Search",
             colorFilter = ColorFilter.tint(

--- a/demoAppRow/src/main/java/com/louis993546/metro/demo/appRow/AppRow.kt
+++ b/demoAppRow/src/main/java/com/louis993546/metro/demo/appRow/AppRow.kt
@@ -3,6 +3,7 @@ package com.louis993546.metro.demo.appRow
 import android.graphics.drawable.Drawable
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Row
@@ -22,7 +23,6 @@ import androidx.compose.ui.unit.sp
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
 import com.louis993546.metro.LocalAccentColor
 import com.louis993546.metro.Text
-import com.louis993546.metro.forceTapAnimation
 
 @Composable
 fun AppIcon(
@@ -45,7 +45,7 @@ fun AppRow(
 ) {
     Row(
         modifier = modifier
-            .forceTapAnimation()
+            .clickable { }
             .fillMaxSize()
     ) {
         AppIcon {

--- a/demoLauncher/src/main/java/com/louis993546/metro/demo/launcher/Launcher.kt
+++ b/demoLauncher/src/main/java/com/louis993546/metro/demo/launcher/Launcher.kt
@@ -3,7 +3,7 @@ package com.louis993546.metro.demo.launcher
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -16,7 +16,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -27,8 +26,6 @@ import com.louis993546.metro.LocalTextOnBackgroundColor
 import com.louis993546.metro.Text
 import com.louis993546.metro.demo.VerticalTilesGrid
 import com.louis993546.metro.demo.apps.Apps
-import com.louis993546.metro.forceTapAnimation
-import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Suppress LongMethod, as in long run, this whole thing should be configurable by the users
@@ -144,17 +141,13 @@ fun HomePage(
             modifier = Modifier
                 .align(Alignment.End)
                 .padding(8.dp)
+                .clickable {
+                    onArrowClick()
+                }
         ) {
             Image(
                 modifier = Modifier
-                    .padding(6.dp)
-                    .pointerInput(Unit) {
-                        detectTapGestures(
-                            onPress = {
-                                onArrowClick()
-                            }
-                        )
-                    },
+                    .padding(6.dp),
                 painter = painterResource(id = R.drawable.ic_baseline_arrow_forward_24),
                 contentDescription = "Apps list",
                 colorFilter = ColorFilter.tint(
@@ -181,43 +174,35 @@ fun HomeTile(
 ) {
     Box(
         modifier = Modifier
-            .forceTapAnimation()
-            .background(color = backgroundColor)
-            .pointerInput(Unit) {
-                detectTapGestures(
-                    onPress = {
-                        @Suppress("SwallowedException")
-                        val released = try {
-                            tryAwaitRelease()
-                        } catch (c: CancellationException) {
-                            false
-                        }
-
-                        if (released && activate != null)
-                            activate()
-                    }
-                )
+            .clickable {
+                activate?.invoke()
             }
     ) {
-        iconRes?.let { res ->
-            Image(
+        Box(
+            modifier = Modifier
+                .background(color = backgroundColor)
+                .fillMaxSize()
+        ) {
+            iconRes?.let { res ->
+                Image(
+                    modifier = Modifier
+                        .size(36.dp)
+                        .align(Alignment.Center),
+                    painter = painterResource(id = res),
+                    contentDescription = "", // TODO fix me
+                    colorFilter = ColorFilter.tint(textColor),
+                )
+            }
+
+            Text(
                 modifier = Modifier
-                    .size(36.dp)
-                    .align(Alignment.Center),
-                painter = painterResource(id = res),
-                contentDescription = "", // TODO fix me
-                colorFilter = ColorFilter.tint(textColor),
+                    .align(Alignment.BottomStart)
+                    .padding(start = 10.dp, bottom = 6.dp),
+                text = title,
+                size = 18.sp,
+                color = textColor,
+                maxLine = 1
             )
         }
-
-        Text(
-            modifier = Modifier
-                .align(Alignment.BottomStart)
-                .padding(start = 10.dp, bottom = 6.dp),
-            text = title,
-            size = 18.sp,
-            color = textColor,
-            maxLine = 1
-        )
     }
 }

--- a/metro/api/metro.api
+++ b/metro/api/metro.api
@@ -6,8 +6,6 @@ public final class com/louis993546/metro/ApplicationBarKt {
 public final class com/louis993546/metro/ButtonsKt {
 	public static final fun Button (Landroidx/compose/ui/Modifier;Ljava/lang/String;Landroidx/compose/runtime/Composer;II)V
 	public static final fun CircleButton (Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
-	public static final fun forceTapAnimation (Landroidx/compose/ui/Modifier;F)Landroidx/compose/ui/Modifier;
-	public static synthetic fun forceTapAnimation$default (Landroidx/compose/ui/Modifier;FILjava/lang/Object;)Landroidx/compose/ui/Modifier;
 }
 
 public final class com/louis993546/metro/FontFamilyKt {
@@ -114,5 +112,9 @@ public final class com/louis993546/metro/TextKt {
 
 public final class com/louis993546/metro/TileKt {
 	public static final fun Tile (Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class com/louis993546/metro/TiltIndicationKt {
+	public static final fun rememberTiltIndication (FFFLandroidx/compose/runtime/Composer;II)Landroidx/compose/foundation/Indication;
 }
 

--- a/metro/src/main/java/com/louis993546/metro/Buttons.kt
+++ b/metro/src/main/java/com/louis993546/metro/Buttons.kt
@@ -1,29 +1,15 @@
 package com.louis993546.metro
 
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.gestures.awaitFirstDown
-import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.composed
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -31,23 +17,13 @@ fun Button(
     modifier: Modifier = Modifier,
     text: String
 ) {
-    val state = remember { mutableStateOf(false) }
+    // TODO Button indication
     Box(
         modifier = modifier
-            .forceTapAnimation()
-            .pointerInput(Unit) {
-                detectTapGestures(
-                    onPress = {
-                        state.value = true
-                        awaitRelease()
-                        state.value = false
-                    }
-                )
-            }
-            .background(color = if (state.value) LocalTextOnBackgroundColor.current else Color.Transparent)
+            .background(color = Color.Transparent)
             .border(
                 width = 3.dp,
-                color = if (state.value) LocalTextOnBackgroundColor.current else LocalTextOnBackgroundColor.current
+                color = LocalTextOnBackgroundColor.current
             ),
         contentAlignment = Alignment.Center,
     ) {
@@ -57,7 +33,7 @@ fun Button(
                 .padding(horizontal = 12.dp),
 
             text = text,
-            color = if (state.value) LocalBackgroundColor.current else LocalTextOnBackgroundColor.current,
+            color = LocalTextOnBackgroundColor.current,
         )
     }
 }
@@ -67,76 +43,17 @@ fun CircleButton(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
-    val state = remember { mutableStateOf(false) }
     Box(
         modifier = modifier
-            .forceTapAnimation()
-            .pointerInput(Unit) {
-                detectTapGestures(
-                    onPress = {
-                        state.value = true
-                        awaitRelease()
-                        state.value = false
-                    }
-                )
-            }
             .clip(CircleShape)
-            .background(color = if (state.value) LocalTextOnBackgroundColor.current else Color.Transparent)
+            .background(color = Color.Transparent)
             .border(
                 width = 3.dp,
-                color = if (state.value) LocalTextOnBackgroundColor.current else LocalTextOnBackgroundColor.current,
+                color = LocalTextOnBackgroundColor.current,
                 shape = CircleShape
             ),
         contentAlignment = Alignment.Center,
     ) {
         content()
     }
-}
-
-/**
- * Windows Phone 8.1-like tap animation
- */
-private enum class ButtonState { Pressed, Idle }
-fun Modifier.forceTapAnimation(
-        effect: Float = 5f
-) = composed {
-    var buttonState by remember { mutableStateOf(ButtonState.Idle) }
-    var touchedPoint by remember { mutableStateOf(Offset.Zero) }
-    var size by remember { mutableStateOf(IntSize.Zero) }
-
-    val scale by animateFloatAsState(if (buttonState == ButtonState.Pressed) 0.95f else 1f)
-    val tilt by animateFloatAsState(if (buttonState == ButtonState.Pressed) effect else 0f)
-
-    this
-        .onGloballyPositioned {
-            size = it.size
-        }
-        .graphicsLayer {
-            scaleX = scale
-            scaleY = scale
-
-            // TODO Allow for just tilting in one direction
-            // TODO Different tilt amount per size
-            // TODO Allow for no-tilt and just being pressed down (eg centered tap)
-            //   in other words move this from two booleans to a proper 2d map.
-            if (touchedPoint.y != 0f)
-                rotationX = if (touchedPoint.y > (size.height / 2)) -tilt else tilt
-            if (touchedPoint.x != 0f)
-                rotationY = if (touchedPoint.x < (size.width / 2)) -tilt else tilt
-        }
-        .pointerInput(buttonState) {
-            awaitPointerEventScope {
-                buttonState = if (buttonState == ButtonState.Pressed) {
-                    waitForUpOrCancellation()
-                    ButtonState.Idle
-                } else {
-                    awaitFirstDown(false)
-
-                    var event = this.currentEvent.changes[0]
-                    touchedPoint = event.position
-
-                    ButtonState.Pressed
-                }
-            }
-        }
 }

--- a/metro/src/main/java/com/louis993546/metro/ListView.kt
+++ b/metro/src/main/java/com/louis993546/metro/ListView.kt
@@ -72,7 +72,6 @@ fun AcronymIcon(
 ) {
     Box(
         modifier = modifier
-            .forceTapAnimation()
             .background(color = LocalBackgroundColor.current)
             .height(62.dp)
     ) {

--- a/metro/src/main/java/com/louis993546/metro/MetroTheme.kt
+++ b/metro/src/main/java/com/louis993546/metro/MetroTheme.kt
@@ -1,5 +1,6 @@
 package com.louis993546.metro
 
+import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -33,6 +34,7 @@ fun MetroTheme(
         LocalTextOnBackgroundColor provides textOnBackgroundColor,
         LocalButtonColor provides buttonColor,
         LocalTextOnButtonColor provides textOnBackgroundColor, // this is close enough for now
+        LocalIndication provides TiltIndication()
     ) {
         content()
     }

--- a/metro/src/main/java/com/louis993546/metro/TiltIndication.kt
+++ b/metro/src/main/java/com/louis993546/metro/TiltIndication.kt
@@ -1,0 +1,192 @@
+package com.louis993546.metro
+
+import android.graphics.Camera
+import android.graphics.Matrix
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Indication
+import androidx.compose.foundation.IndicationInstance
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.drawscope.scale
+import androidx.compose.ui.graphics.nativeCanvas
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+
+/**
+ * Creates and [remember]s a [TiltIndication].
+ *
+ * [TiltIndication] is a Metro implementation of [Indication] that
+ * expresses [Interaction]s by tilting the component based on the
+ * pointer position.
+ *
+ * @param activeScale Target scaling when activated.
+ * @param inactiveScale Scaling when inactive.
+ * @param intensity Degree of intensity for the tilt effect.
+ *
+ * @author Filiph Siitam Sandström <filiph.sandstrom@filfatstudios.com>
+ */
+@Composable
+fun rememberTiltIndication(
+    activeScale: Float = 0.98f,
+    inactiveScale: Float = 1f,
+    intensity: Float = 7.5f
+): Indication {
+    return remember(activeScale, inactiveScale, intensity) {
+        TiltIndication(
+            scaleMin = activeScale,
+            scaleMax = inactiveScale,
+            intensity = intensity
+        )
+    }
+}
+
+internal class TiltIndication(
+    private val scaleMin: Float = 0.98f,
+    private val scaleMax: Float = 1f,
+    private val intensity: Float = 7.5f
+) : Indication {
+    @Composable
+    override fun rememberUpdatedInstance(
+        interactionSource: InteractionSource
+    ): IndicationInstance {
+        val active = remember { mutableStateOf(false) }
+        val animationState = animateFloatAsState(
+            targetValue = if (active.value) 1f else 0f,
+            animationSpec = tween(
+                durationMillis = 125
+            ),
+            label = "TiltAnimation"
+        )
+
+        val instance = remember {
+            TiltIndicationInstance(
+                scaleMin = scaleMin,
+                scaleMax = scaleMax,
+                intensity = intensity,
+                animationState = animationState
+            )
+        }
+
+        LaunchedEffect(interactionSource) {
+            interactionSource.interactions.collect { interaction ->
+                when (interaction) {
+                    is PressInteraction.Press -> {
+                        active.value = true
+                        instance.start(
+                            scope = this,
+                            position = interaction.pressPosition
+                        )
+                    }
+                    is PressInteraction.Release,
+                    is PressInteraction.Cancel -> {
+                        active.value = false
+                        instance.stop()
+                    }
+                }
+            }
+        }
+
+        return instance
+    }
+}
+
+private class TiltIndicationInstance(
+    private val scaleMin: Float,
+    private val scaleMax: Float,
+    private val intensity: Float,
+    private val animationState: State<Float>
+) : IndicationInstance {
+    private var componentSize = Size.Zero
+    private var rotation = Offset.Zero
+    private var finishEvent = Channel<Unit>(Channel.CONFLATED)
+
+    fun start(scope: CoroutineScope, position: Offset) {
+        scope.launch {
+            var x = 0f
+            var y = 0f
+
+            if (position.x < componentSize.width / 3) {
+                x += -intensity
+            } else if (position.x > (componentSize.width / 3) * 2) {
+                x += intensity
+            }
+
+            if (position.y < componentSize.height / 3) {
+                y += intensity
+            } else if (position.y > (componentSize.height / 3) * 2) {
+                y += -intensity
+            }
+
+            rotation = Offset(x, y)
+        }
+        scope.launch {
+            finishEvent.receive()
+        }
+    }
+
+    fun stop() {
+        finishEvent.trySend(Unit)
+    }
+
+    private val matrix = Matrix()
+    private val camera = Camera()
+
+    /**
+     * We would need access to [Modifier] to properly animate,
+     * as far as I can tell there is no way to do this as
+     * of now.
+     *
+     * An alternative would be if [DrawScope] supported
+     * proper rotation.
+     *
+     * Instead we now have to use the built-in method to create
+     * a virtual [Camera] and do a bunch of [Matrix] calculations.
+     * Luckily this is actually quite performant.
+     *
+     * TODO Maybe file an issue with jetpack compose upstream?
+     */
+    override fun ContentDrawScope.drawIndication() {
+        if (rotation.y == 0f && rotation.x == 0f) {
+            // Convert 0.0-1.0 to scaleMin->scaleMax
+            val scale =
+                (((1f - animationState.value) - 0f) / (1f - 0f)) * (scaleMax - scaleMin) + scaleMin
+
+            drawContext.transform.apply {
+                scale(scale, center)
+            }
+        }
+
+        componentSize = size
+        this.drawIntoCanvas { canvas ->
+            camera.save()
+            camera.rotateX(rotation.y * animationState.value)
+            camera.rotateY(rotation.x * animationState.value)
+            camera.rotateZ(0f)
+            camera.getMatrix(matrix)
+
+            val x = center.x
+            val y = center.y
+            matrix.preTranslate(-x, -y)
+            matrix.postTranslate(x, y)
+
+            canvas.nativeCanvas.concat(matrix)
+            camera.restore()
+        }
+
+        drawContent()
+    }
+}


### PR DESCRIPTION
The commit description summarizes this pretty well
```
Fixes #192.

This was a real PITA to reverse engineer and figure out thanks to the
lackluster `Indication` and `Interaction` documentation.

The API is also missing some expected features like proper rotation
so instead we have to use `android.graphics.Camera` for the actual
tilting effect.

Hopefully my pain reverse engineering `rememberRipple`& co and then
subsequent sharing of a real-world reimplementation will prevent
future generations from having to suffer the same way I have.

Y'all have been forewarned, if you choose to tread where I've tread
you'll only experience madness.
```

Fixes #192 