### PR TITLE
Add `.devcontainer`.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,71 @@
+{
+    "name": "Metro-Compose",
+    "image": "mcr.microsoft.com/devcontainers/base:jammy",
+    "features": {
+        "ghcr.io/devcontainers/features/java:1": {
+            "version": "20",
+            "jdkDistro": "open",
+            "installGradle": true,
+            "gradleVersion": "8.2"
+        },
+        "ghcr.io/NordcomInc/devcontainer-features/android-sdk:1": {
+            "platform": "34"
+        },
+        "ghcr.io/devcontainers-contrib/features/kotlin-sdkman:2": {
+            "jdkVersion": "20",
+            "jdkDistro": "open"
+        },
+        "ghcr.io/mikaello/devcontainer-features/kotlinc:1": {}
+    },
+    "overrideFeatureInstallOrder": [
+        "ghcr.io/devcontainers/features/java:1",
+        "ghcr.io/NordcomInc/devcontainer-features/android-sdk:1",
+        "ghcr.io/devcontainers-contrib/features/kotlin-sdkman:2",
+        "ghcr.io/mikaello/devcontainer-features/kotlinc:1"
+    ],
+    "forwardPorts": [
+        5037,
+        5555
+    ],
+    "portsAttributes": {
+        "5037": {
+            "forwardPort": 5037,
+            "displayName": "ADB",
+            "requireLocalPort": true,
+            "elevateIfNeeded": true
+        },
+        "5555": {
+            "forwardPort": 5555,
+            "displayName": "ADB over WIFI",
+            "requireLocalPort": true,
+            "elevateIfNeeded": true
+        }
+    },
+    // Required for ADB USB debugging.
+    "privileged": true,
+    "mounts": [
+        "source=/dev/bus/usb,target=/dev/bus/usb,type=bind"
+    ],
+    // Automatically start ADB.
+    "postCreateCommand": {
+        "adb-server": "adb start-server"
+    },
+    // Language-support.
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "mathiasfrohlich.Kotlin",
+                "vscjava.vscode-gradle"
+            ],
+            "settings": {
+                "editor.tabSize": 4,
+                "terminal.integrated.defaultProfile.linux": "zsh",
+                "terminal.integrated.profiles.linux": {
+                    "zsh": {
+                        "path": "zsh"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/docs/debugging-on-wsl2.md
+++ b/docs/debugging-on-wsl2.md
@@ -1,0 +1,8 @@
+# Debugging on WSL2
+
+WSL2 doesn't yet natively support USB devices but there's an open source project
+which adds support https://learn.microsoft.com/en-us/windows/wsl/connect-usb .
+
+After attatching your device with `usbipd wsl attach --busid=<BUSID>` using a
+PowerShell instance with admin privileges it'll be available in WSL2, both directly
+and containerized using the `.devcontainer`.


### PR DESCRIPTION
Fully containerized (and cloud if you really wanted) builds through vscode's `.devcontainer` and GitHub Codespaces. Also makes it a whole lot more comfortable to get up and running on a new machine while also fixing most pain points of developing on Windows. (Had to create my own Android SDK `.devcontainer` feature, which was neat I guess).

![image](https://github.com/louis993546/Metro-Compose/assets/108444335/56f82c3b-ada0-45f3-a560-fe7422a6e8f3)
> Built `Metro-Compose` with the cheapest/almost-free tier of Codespaces at an acceptable pace too.
